### PR TITLE
fixed 404 title size

### DIFF
--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -4,7 +4,7 @@ import Button from "@/components/Button";
 const NotFound = () => {
   return (
     <div className="flex flex-col items-center justify-center h-screen overscroll-none">
-      <Title text="404" className="text-7xl md:text-7xl" />
+      <Title text="404" size="text-7xl md:text-7xl" />
 
       <p className="text-3xl font-bold bg-gradient-to-r from-isa-blue-200 to-isa-blue-100 text-transparent bg-clip-text mb-3">
         Page Not Found

--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -1,9 +1,11 @@
 import Title from "@/components/Title";
 import Button from "@/components/Button";
+
 const NotFound = () => {
   return (
     <div className="flex flex-col items-center justify-center h-screen overscroll-none">
-      <Title text="404" />
+      <Title text="404" className={"text-7xl md:text-7xl"} />
+
       <p className="text-3xl font-bold bg-gradient-to-r from-isa-blue-200 to-isa-blue-100 text-transparent bg-clip-text mb-3">
         Page Not Found
       </p>

--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -4,7 +4,7 @@ import Button from "@/components/Button";
 const NotFound = () => {
   return (
     <div className="flex flex-col items-center justify-center h-screen overscroll-none">
-      <Title text="404" className={"text-7xl md:text-7xl"} />
+      <Title text="404" className="text-7xl md:text-7xl" />
 
       <p className="text-3xl font-bold bg-gradient-to-r from-isa-blue-200 to-isa-blue-100 text-transparent bg-clip-text mb-3">
         Page Not Found

--- a/src/components/Title.jsx
+++ b/src/components/Title.jsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { PiStarFourFill } from "react-icons/pi";
 
-const Title = ({ text }) => {
+const Title = ({ text, className }) => {
   return (
     <div className="flex-col flex items-center">
-      <div className="text-isa-yellow-200 text-center font-extrabold md:text-4xl text-3xl">
+      <div
+        className={`text-isa-yellow-200 text-center font-extrabold md:text-4xl text-3xl ${className}`}
+      >
         {text}
       </div>
 

--- a/src/components/Title.jsx
+++ b/src/components/Title.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { PiStarFourFill } from "react-icons/pi";
 
-const Title = ({ text, className }) => {
+const Title = ({ text, size = "text-3xl" }) => {
   return (
     <div className="flex-col flex items-center">
       <div
-        className={`text-isa-yellow-200 text-center font-extrabold md:text-4xl text-3xl ${className}`}
+        className={`text-isa-yellow-200 text-center font-extrabold md:text-4xl ${size}`}
       >
         {text}
       </div>


### PR DESCRIPTION
![image](https://github.com/acm-ucr/isa-website/assets/93236538/fe18df73-2316-4575-8ae7-ad0147956c70)

Uses text-7xl. Does not overwrite other Title components if no className prop is provided. 
Closes #111 .